### PR TITLE
Router 및 context 추가

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,23 @@
 module.exports = {
   env: { browser: true, es6: true, node: true },
   extends: ['airbnb', 'plugin:prettier/recommended'],
+  parser: '@typescript-eslint/parser',
+  settings: {
+    'import/resolver': {
+      typescript: {},
+    },
+  },
   rules: {
-    'react/jsx-filename-extension': 1,
+    'react/jsx-filename-extension': [1, { extensions: ['.tsx'] }],
     'import/no-unresolved': 1,
-    'import/extensions': 1,
+    'import/extensions': [
+      1,
+      'ignorePackages',
+      {
+        ts: 'never',
+        tsx: 'never',
+      },
+    ],
     'no-unused-vars': 1,
     'prettier/prettier': [
       'error',

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.6.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -53,9 +53,10 @@
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.47.0",
-    "@typescript-eslint/parser": "^5.47.0",
+    "@typescript-eslint/parser": "^5.47.1",
     "eslint": "^8.30.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-import-resolver-typescript": "^3.5.2",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import logo from './logo.svg';
 import './App.css';
 import { Route, Routes } from 'react-router-dom';
 import Home from './pages/Home';
@@ -18,6 +17,8 @@ import Personal from './pages/Personal';
 import PersonalSeries from './pages/PersonalSeries';
 import PersonalSeriesName from './pages/PersonalSeriesName';
 import PersonalAbout from './pages/PersonalAbout';
+import PersonalPost from './pages/PersonalPost';
+import NotFound from './pages/NotFound';
 
 function App() {
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,52 @@
 import React from 'react';
 import logo from './logo.svg';
 import './App.css';
+import { Route, Routes } from 'react-router-dom';
+import Home from './pages/Home';
+import Recent from './pages/Recent';
+import Search from './pages/Search';
+import Write from './pages/Write';
+import Saves from './pages/Saves';
+import Setting from './pages/Setting';
+import Follows from './pages/Follows';
+import ListsLiked from './pages/ListsLiked';
+import ListsRead from './pages/ListsRead';
+import ListsFollowing from './pages/ListsFollowing';
+import Tags from './pages/Tags';
+import TagsTag from './pages/TagsTag';
+import Personal from './pages/Personal';
+import PersonalSeries from './pages/PersonalSeries';
+import PersonalSeriesName from './pages/PersonalSeriesName';
+import PersonalAbout from './pages/PersonalAbout';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload. deploy test.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/recent" element={<Recent />} />
+      <Route path="/search" element={<Search />} />
+      <Route path="/write" element={<Write />} />
+      <Route path="/saves" element={<Saves />} />
+      <Route path="/setting" element={<Setting />} />
+      <Route path="/follows" element={<Follows />} />
+      <Route path="/lists">
+        <Route path="liked" element={<ListsLiked />} />
+        <Route path="read" element={<ListsRead />} />
+        <Route path="following" element={<ListsFollowing />} />
+        <Route path="" element={<NotFound />} />
+      </Route>
+      <Route path="/tags" element={<Tags />}>
+        <Route path=":tag" element={<TagsTag />} />
+      </Route>
+      <Route path="/:id" element={<Personal />}>
+        <Route path="series" element={<PersonalSeries />}>
+          <Route path=":seriesName" element={<PersonalSeriesName />} />
+        </Route>
+        <Route path="about" element={<PersonalAbout />} />
+        <Route path=":postTitle" element={<PersonalPost />} />
+      </Route>
+      <Route path="/*" element={<NotFound />} />
+    </Routes>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,11 +36,14 @@ function App() {
         <Route path="following" element={<ListsFollowing />} />
         <Route path="" element={<NotFound />} />
       </Route>
-      <Route path="/tags" element={<Tags />}>
+      <Route path="/tags">
+        <Route path="" element={<Tags />} />
         <Route path=":tag" element={<TagsTag />} />
       </Route>
-      <Route path="/:id" element={<Personal />}>
-        <Route path="series" element={<PersonalSeries />}>
+      <Route path="/:id">
+        <Route path="" element={<Personal />} />
+        <Route path="series">
+          <Route path="" element={<PersonalSeries />} />
           <Route path=":seriesName" element={<PersonalSeriesName />} />
         </Route>
         <Route path="about" element={<PersonalAbout />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,38 +19,45 @@ import PersonalSeriesName from './pages/PersonalSeriesName';
 import PersonalAbout from './pages/PersonalAbout';
 import PersonalPost from './pages/PersonalPost';
 import NotFound from './pages/NotFound';
+import ModalProvider from './contexts/ModalProvider';
+
+function AppProvider({ children }: { children: React.ReactNode }) {
+  return <ModalProvider>{children}</ModalProvider>;
+}
 
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/recent" element={<Recent />} />
-      <Route path="/search" element={<Search />} />
-      <Route path="/write" element={<Write />} />
-      <Route path="/saves" element={<Saves />} />
-      <Route path="/setting" element={<Setting />} />
-      <Route path="/follows" element={<Follows />} />
-      <Route path="/lists">
-        <Route path="liked" element={<ListsLiked />} />
-        <Route path="read" element={<ListsRead />} />
-        <Route path="following" element={<ListsFollowing />} />
-        <Route path="" element={<NotFound />} />
-      </Route>
-      <Route path="/tags">
-        <Route path="" element={<Tags />} />
-        <Route path=":tag" element={<TagsTag />} />
-      </Route>
-      <Route path="/:id">
-        <Route path="" element={<Personal />} />
-        <Route path="series">
-          <Route path="" element={<PersonalSeries />} />
-          <Route path=":seriesName" element={<PersonalSeriesName />} />
+    <AppProvider>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/recent" element={<Recent />} />
+        <Route path="/search" element={<Search />} />
+        <Route path="/write" element={<Write />} />
+        <Route path="/saves" element={<Saves />} />
+        <Route path="/setting" element={<Setting />} />
+        <Route path="/follows" element={<Follows />} />
+        <Route path="/lists">
+          <Route path="liked" element={<ListsLiked />} />
+          <Route path="read" element={<ListsRead />} />
+          <Route path="following" element={<ListsFollowing />} />
+          <Route path="" element={<NotFound />} />
         </Route>
-        <Route path="about" element={<PersonalAbout />} />
-        <Route path=":postTitle" element={<PersonalPost />} />
-      </Route>
-      <Route path="/*" element={<NotFound />} />
-    </Routes>
+        <Route path="/tags">
+          <Route path="" element={<Tags />} />
+          <Route path=":tag" element={<TagsTag />} />
+        </Route>
+        <Route path="/:id">
+          <Route path="" element={<Personal />} />
+          <Route path="series">
+            <Route path="" element={<PersonalSeries />} />
+            <Route path=":seriesName" element={<PersonalSeriesName />} />
+          </Route>
+          <Route path="about" element={<PersonalAbout />} />
+          <Route path=":postTitle" element={<PersonalPost />} />
+        </Route>
+        <Route path="/*" element={<NotFound />} />
+      </Routes>
+    </AppProvider>
   );
 }
 

--- a/src/contexts/ModalProvider.tsx
+++ b/src/contexts/ModalProvider.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable no-unused-vars */
+import React, { createContext, useContext, useMemo, useState } from 'react';
+
+type modalType = { visible: boolean; message: string };
+const initialModal = { visible: false, message: '' };
+
+type actionsType = {
+  open: (message: string) => void;
+  close: () => void;
+};
+const initialActions: actionsType = {
+  open: (message: string) => undefined,
+  close: () => undefined,
+};
+
+const ModalValueContext = createContext<modalType>(initialModal);
+const ModalActionsContext = createContext<actionsType>(initialActions);
+
+export default function ModalProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [modal, setModal] = useState({
+    visible: false,
+    message: '',
+  });
+
+  const actions = useMemo(
+    () => ({
+      open(message: string) {
+        setModal({
+          message,
+          visible: true,
+        });
+      },
+      close() {
+        setModal(prev => ({
+          ...prev,
+          visible: false,
+        }));
+      },
+    }),
+    []
+  );
+
+  return (
+    <ModalActionsContext.Provider value={actions}>
+      <ModalValueContext.Provider value={modal}>
+        {children}
+      </ModalValueContext.Provider>
+    </ModalActionsContext.Provider>
+  );
+}
+
+function useModalValue() {
+  const value = useContext(ModalValueContext);
+  if (value === undefined) {
+    throw new Error('useModalValue should be used within ModalProvider');
+  }
+  return value;
+}
+
+function useModalActions() {
+  const value = useContext(ModalActionsContext);
+  if (value === undefined) {
+    throw new Error('useModalActions should be used within ModalProvider');
+  }
+  return value;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,13 +3,16 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { BrowserRouter } from 'react-router-dom';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import { BrowserRouter } from 'react-router-dom';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/src/pages/Follows.tsx
+++ b/src/pages/Follows.tsx
@@ -1,1 +1,7 @@
-export default function Follows() {}
+import React from 'react';
+
+function Follows() {
+  return <div>Follows</div>;
+}
+
+export default Follows;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,1 +1,7 @@
-export default function Home() {}
+import React from 'react';
+
+function Home() {
+  return <div>Home</div>;
+}
+
+export default Home;

--- a/src/pages/ListsFollowing.tsx
+++ b/src/pages/ListsFollowing.tsx
@@ -1,1 +1,7 @@
-export default function ListsFollowing() {}
+import React from 'react';
+
+function ListsFollowing() {
+  return <div>ListsFollowing</div>;
+}
+
+export default ListsFollowing;

--- a/src/pages/ListsLiked.tsx
+++ b/src/pages/ListsLiked.tsx
@@ -1,1 +1,7 @@
-export default function ListsLiked() {}
+import React from 'react';
+
+function ListsLiked() {
+  return <div>ListsLiked</div>;
+}
+
+export default ListsLiked;

--- a/src/pages/ListsRead.tsx
+++ b/src/pages/ListsRead.tsx
@@ -1,1 +1,7 @@
-export default function ListsRead() {}
+import React from 'react';
+
+function ListsRead() {
+  return <div>ListsRead</div>;
+}
+
+export default ListsRead;

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function NotFound() {
+  return <div>NotFound</div>;
+}
+
+export default NotFound;

--- a/src/pages/Personal.tsx
+++ b/src/pages/Personal.tsx
@@ -1,1 +1,7 @@
-export default function Personal() {}
+import React from 'react';
+
+function Personal() {
+  return <div>Personal</div>;
+}
+
+export default Personal;

--- a/src/pages/PersonalAbout.tsx
+++ b/src/pages/PersonalAbout.tsx
@@ -1,1 +1,7 @@
-export default function PersonalAbout() {}
+import React from 'react';
+
+function PersonalAbout() {
+  return <div>PersonalAbout</div>;
+}
+
+export default PersonalAbout;

--- a/src/pages/PersonalPost.tsx
+++ b/src/pages/PersonalPost.tsx
@@ -1,1 +1,7 @@
-export default function PersonalPost() {}
+import React from 'react';
+
+function PersonalPost() {
+  return <div>PersonalPost</div>;
+}
+
+export default PersonalPost;

--- a/src/pages/PersonalSeries.tsx
+++ b/src/pages/PersonalSeries.tsx
@@ -1,1 +1,7 @@
-export default function PersonalSeries() {}
+import React from 'react';
+
+function PersonalSeries() {
+  return <div>PersonalSeries</div>;
+}
+
+export default PersonalSeries;

--- a/src/pages/PersonalSeriesName.tsx
+++ b/src/pages/PersonalSeriesName.tsx
@@ -1,1 +1,7 @@
-export default function PersonalSeriesName() {}
+import React from 'react';
+
+function PersonalSeriesName() {
+  return <div>PersonalSeriesName</div>;
+}
+
+export default PersonalSeriesName;

--- a/src/pages/Recent.tsx
+++ b/src/pages/Recent.tsx
@@ -1,1 +1,7 @@
-export default function Recent() {}
+import React from 'react';
+
+function Recent() {
+  return <div>Recent</div>;
+}
+
+export default Recent;

--- a/src/pages/Saves.tsx
+++ b/src/pages/Saves.tsx
@@ -1,1 +1,7 @@
-export default function Saves() {}
+import React from 'react';
+
+function Saves() {
+  return <div>Saves</div>;
+}
+
+export default Saves;

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,1 +1,7 @@
-export default function Search() {}
+import React from 'react';
+
+function Search() {
+  return <div>Search</div>;
+}
+
+export default Search;

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -1,1 +1,7 @@
-export default function Setting() {}
+import React from 'react';
+
+function Setting() {
+  return <div>Setting</div>;
+}
+
+export default Setting;

--- a/src/pages/Tags.tsx
+++ b/src/pages/Tags.tsx
@@ -1,1 +1,7 @@
-export default function Tags() {}
+import React from 'react';
+
+function Tags() {
+  return <div>Tags</div>;
+}
+
+export default Tags;

--- a/src/pages/TagsTag.tsx
+++ b/src/pages/TagsTag.tsx
@@ -1,1 +1,7 @@
-export default function TagsTag() {}
+import React from 'react';
+
+function TagsTag() {
+  return <div>TagsTag</div>;
+}
+
+export default TagsTag;

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -1,1 +1,7 @@
-export default function Write() {}
+import React from 'react';
+
+function Write() {
+  return <div>Write</div>;
+}
+
+export default Write;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,6 +1575,11 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@remix-run/router@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.2.1.tgz#812edd4104a15a493dda1ccac0b352270d7a188c"
+  integrity sha512-XiY0IsyHR+DXYS5vBxpoBe/8veTeoRpMHP+vDosLZxL5bnpetzI0igkxkLZS235ldLzyfkxF+2divEwWHP3vMQ==
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -7504,6 +7509,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.6.1.tgz#1b96ec0b2cefa7319f1251383ea5b41295ee260d"
+  integrity sha512-u+8BKUtelStKbZD5UcY0NY90WOzktrkJJhyhNg7L0APn9t1qJNLowzrM9CHdpB6+rcPt6qQrlkIXsTvhuXP68g==
+  dependencies:
+    "@remix-run/router" "1.2.1"
+    react-router "6.6.1"
+
+react-router@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.6.1.tgz#17de6cf285f2d1c9721a3afca999c984e5558854"
+  integrity sha512-YkvlYRusnI/IN0kDtosUCgxqHeulN5je+ew8W+iA1VvFhf86kA+JEI/X/8NqYcr11hCDDp906S+SGMpBheNeYQ==
+  dependencies:
+    "@remix-run/router" "1.2.1"
 
 react-scripts@5.0.1:
   version "5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1560,6 +1560,18 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@pkgr/utils@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.3.1.tgz#0a9b06ffddee364d6642b3cd562ca76f55b34a03"
+  integrity sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==
+  dependencies:
+    cross-spawn "^7.0.3"
+    is-glob "^4.0.3"
+    open "^8.4.0"
+    picocolors "^1.0.0"
+    tiny-glob "^0.2.9"
+    tslib "^2.4.0"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.10"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.10.tgz#2eba163b8e7dbabb4ce3609ab5e32ab63dda3ef8"
@@ -2161,7 +2173,17 @@
   dependencies:
     "@typescript-eslint/utils" "5.47.0"
 
-"@typescript-eslint/parser@^5.47.0", "@typescript-eslint/parser@^5.5.0":
+"@typescript-eslint/parser@^5.47.1":
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.47.1.tgz#c4bf16f8c3c7608ce4bf8ff804b677fc899f173f"
+  integrity sha512-9Vb+KIv29r6GPu4EboWOnQM7T+UjpjXvjCPhNORlgm40a9Ia9bvaPJswvtae1gip2QEeVeGh6YquqAzEgoRAlw==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.47.1"
+    "@typescript-eslint/types" "5.47.1"
+    "@typescript-eslint/typescript-estree" "5.47.1"
+    debug "^4.3.4"
+
+"@typescript-eslint/parser@^5.5.0":
   version "5.47.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.47.0.tgz#62e83de93499bf4b500528f74bf2e0554e3a6c8d"
   integrity sha512-udPU4ckK+R1JWCGdQC4Qa27NtBg7w020ffHqGyAK8pAgOVuNw7YaKXGChk+udh+iiGIJf6/E/0xhVXyPAbsczw==
@@ -2179,6 +2201,14 @@
     "@typescript-eslint/types" "5.47.0"
     "@typescript-eslint/visitor-keys" "5.47.0"
 
+"@typescript-eslint/scope-manager@5.47.1":
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.47.1.tgz#0d302b3c2f20ab24e4787bf3f5a0d8c449b823bd"
+  integrity sha512-9hsFDsgUwrdOoW1D97Ewog7DYSHaq4WKuNs0LHF9RiCmqB0Z+XRR4Pf7u7u9z/8CciHuJ6yxNws1XznI3ddjEw==
+  dependencies:
+    "@typescript-eslint/types" "5.47.1"
+    "@typescript-eslint/visitor-keys" "5.47.1"
+
 "@typescript-eslint/type-utils@5.47.0":
   version "5.47.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.47.0.tgz#2b440979c574e317d3473225ae781f292c99e55d"
@@ -2194,6 +2224,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.47.0.tgz#67490def406eaa023dbbd8da42ee0d0c9b5229d3"
   integrity sha512-eslFG0Qy8wpGzDdYKu58CEr3WLkjwC5Usa6XbuV89ce/yN5RITLe1O8e+WFEuxnfftHiJImkkOBADj58ahRxSg==
 
+"@typescript-eslint/types@5.47.1":
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.47.1.tgz#459f07428aec5a8c4113706293c2ae876741ac8e"
+  integrity sha512-CmALY9YWXEpwuu6377ybJBZdtSAnzXLSQcxLSqSQSbC7VfpMu/HLVdrnVJj7ycI138EHqocW02LPJErE35cE9A==
+
 "@typescript-eslint/typescript-estree@5.47.0":
   version "5.47.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.47.0.tgz#ed971a11c5c928646d6ba7fc9dfdd6e997649aca"
@@ -2201,6 +2236,19 @@
   dependencies:
     "@typescript-eslint/types" "5.47.0"
     "@typescript-eslint/visitor-keys" "5.47.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.47.1":
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.47.1.tgz#b9d8441308aca53df7f69b2c67a887b82c9ed418"
+  integrity sha512-4+ZhFSuISAvRi2xUszEj0xXbNTHceV9GbH9S8oAD2a/F9SW57aJNQVOCxG8GPfSWH/X4eOPdMEU2jYVuWKEpWA==
+  dependencies:
+    "@typescript-eslint/types" "5.47.1"
+    "@typescript-eslint/visitor-keys" "5.47.1"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -2227,6 +2275,14 @@
   integrity sha512-ByPi5iMa6QqDXe/GmT/hR6MZtVPi0SqMQPDx15FczCBXJo/7M8T88xReOALAfpBLm+zxpPfmhuEvPb577JRAEg==
   dependencies:
     "@typescript-eslint/types" "5.47.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.47.1":
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.1.tgz#d35c2da544dbb685db9c5b5b85adac0a1d74d1f2"
+  integrity sha512-rF3pmut2JCCjh6BLRhNKdYjULMb1brvoaiWDlHfLNVgmnZ0sBVJrs3SyaKE1XoDDnJuAx/hDQryHYmPUuNq0ig==
+  dependencies:
+    "@typescript-eslint/types" "5.47.1"
     eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.1":
@@ -4018,6 +4074,19 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
+eslint-import-resolver-typescript@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.2.tgz#9431acded7d898fd94591a08ea9eec3514c7de91"
+  integrity sha512-zX4ebnnyXiykjhcBvKIf5TNvt8K7yX6bllTRZ14MiurKPjDpCAZujlszTdB8pcNXhZcOf+god4s9SjQa5GnytQ==
+  dependencies:
+    debug "^4.3.4"
+    enhanced-resolve "^5.10.0"
+    get-tsconfig "^4.2.0"
+    globby "^13.1.2"
+    is-core-module "^2.10.0"
+    is-glob "^4.0.3"
+    synckit "^0.8.4"
+
 eslint-module-utils@^2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974"
@@ -4358,7 +4427,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@^3.2.12, fast-glob@^3.2.9:
+fast-glob@^3.2.11, fast-glob@^3.2.12, fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
@@ -4643,6 +4712,11 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
+get-tsconfig@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.2.0.tgz#ff368dd7104dab47bf923404eb93838245c66543"
+  integrity sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==
+
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -4702,6 +4776,11 @@ globals@^13.19.0:
   dependencies:
     type-fest "^0.20.2"
 
+globalyzer@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/globalyzer/-/globalyzer-0.1.0.tgz#cb76da79555669a1519d5a8edf093afaa0bf1465"
+  integrity sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==
+
 globby@^11.0.4, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
@@ -4713,6 +4792,22 @@ globby@^11.0.4, globby@^11.1.0:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
+
+globby@^13.1.2:
+  version "13.1.3"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.3.tgz#f62baf5720bcb2c1330c8d4ef222ee12318563ff"
+  integrity sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==
+  dependencies:
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.11"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
+
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -5082,7 +5177,7 @@ is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
-is-core-module@^2.8.1, is-core-module@^2.9.0:
+is-core-module@^2.10.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
   integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
@@ -8390,6 +8485,14 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+synckit@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.4.tgz#0e6b392b73fafdafcde56692e3352500261d64ec"
+  integrity sha512-Dn2ZkzMdSX827QbowGbU/4yjWuvNaCoScLLoMo/yKbu+P4GBR6cRGKZH27k6a9bRzdqcyd1DE96pQtQ6uNkmyw==
+  dependencies:
+    "@pkgr/utils" "^2.3.1"
+    tslib "^2.4.0"
+
 tailwindcss@^3.0.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.2.4.tgz#afe3477e7a19f3ceafb48e4b083e292ce0dc0250"
@@ -8497,6 +8600,14 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+tiny-glob@^0.2.9:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/tiny-glob/-/tiny-glob-0.2.9.tgz#2212d441ac17928033b110f8b3640683129d31e2"
+  integrity sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==
+  dependencies:
+    globalyzer "0.1.0"
+    globrex "^0.1.2"
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -8563,7 +8674,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==


### PR DESCRIPTION
페이지들을 테스트해보려면 라우터가 있어야 할 것 같아서 `App.tsx`에 추가해봤습니다.
라우터에 쓰려면 JSX 컴포넌트가 있어야 한다고 해서 모든 페이지에 빈 div를 일단 만들어놨습니다.
`NotFound` 페이지는 따로 추가했습니다.
라우터 설정은 [벨로퍼트님 글](https://velog.io/@velopert/react-router-v6-tutorial#63-notfound-%ED%8E%98%EC%9D%B4%EC%A7%80-%EB%A7%8C%EB%93%A4%EA%B8%B0)을 참고했습니다.

설정하는 김에 Context도 src파일에 폴더를 만들고 관리하는 것 같아서 추가했고,
`App.tsx`에 Provider들을 묶을 AppProvider 컴포넌트를 추가했습니다. 
`ModalProvider`는 그냥 더미로 쓰려고 [벨로퍼트님 벨로그](https://velog.io/@velopert/react-context-tutorial#%EA%B0%92%EA%B3%BC-%EC%97%85%EB%8D%B0%EC%9D%B4%ED%8A%B8-%ED%95%A8%EC%88%98%EB%A5%BC-%EB%91%90%EA%B0%9C%EC%9D%98-context%EB%A1%9C-%EB%B6%84%EB%A6%AC%ED%95%98%EA%B8%B0)에서 긁어왔습니다.

`yarn start`를 하면 eslint가 기본 코드에 에러가 있다면서 막길래 `eslintrc.js`에 관련 설정을 추가했습니다.
관련 설정은 [여기](https://velog.io/@he0_077/React-Typescript-eslint-prettier-%EC%84%A4%EC%A0%95)를 참고했습니다.
관련해서 패키지를 몇 개 설치했는데 `yarn`을 실행하면 알아서 `package.json`이나 `yarn.lock`보고 로컬에 설치되지 않은 패키지를 설치해주는 것 같아요.

찾다보니 air-bnb가 typescript 버전으로 따로 있는 것도 같은데 나중에 추가로 수정해야 할지는 논의를 해봐야 할 것 같아요.
[링크](https://sangjuntech.tistory.com/25)