### PR TITLE
탭 이동 css 효과 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import LoginProvider from './contexts/LoginProvider';
 import Toast from './components/Toast';
 import Modal from './components/Modal';
 import HeaderLayout from './pages/HeaderLayout';
+import PersonalLayout from './pages/PersonalLayout';
 
 function AppProvider({ children }: { children: React.ReactNode }) {
   return (
@@ -60,13 +61,13 @@ function App() {
           <Route path="" element={<Tags />} />
           <Route path=":tag" element={<TagsTag />} />
         </Route>
-        <Route path="/:id">
+        <Route path="/:id" element={<PersonalLayout />}>
           <Route path="" element={<Personal />} />
-          <Route path="series">
-            <Route path="" element={<PersonalSeries />} />
-            <Route path=":seriesName" element={<PersonalSeriesName />} />
-          </Route>
+          <Route path="series" element={<PersonalSeries />} />
           <Route path="about" element={<PersonalAbout />} />
+        </Route>
+        <Route path="/:id">
+          <Route path="series/:seriesName" element={<PersonalSeriesName />} />
           <Route path=":postTitle" element={<PersonalPost />} />
         </Route>
         <Route path="/*" element={<NotFound />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import ModalProvider from './contexts/ModalProvider';
 import LoginProvider from './contexts/LoginProvider';
 import Toast from './components/Toast';
 import Modal from './components/Modal';
+import HeaderLayout from './pages/HeaderLayout';
 
 function AppProvider({ children }: { children: React.ReactNode }) {
   return (
@@ -38,20 +39,22 @@ function App() {
   return (
     <AppProvider>
       <Routes>
-        <Route path="/" element={<Home />} />
         <Route path="/register" element={<Register />} />
         <Route path="/login" element={<Login />} />
-        <Route path="/recent" element={<Recent />} />
         <Route path="/search" element={<Search />} />
         <Route path="/write" element={<Write />} />
         <Route path="/saves" element={<Saves />} />
         <Route path="/setting" element={<Setting />} />
         <Route path="/follows" element={<Follows />} />
-        <Route path="/lists">
-          <Route path="liked" element={<ListsLiked />} />
-          <Route path="read" element={<ListsRead />} />
-          <Route path="following" element={<ListsFollowing />} />
-          <Route path="" element={<NotFound />} />
+        <Route element={<HeaderLayout />}>
+          <Route path="/" element={<Home />} />
+          <Route path="/recent" element={<Recent />} />
+          <Route path="/lists">
+            <Route path="liked" element={<ListsLiked />} />
+            <Route path="read" element={<ListsRead />} />
+            <Route path="following" element={<ListsFollowing />} />
+            <Route path="" element={<NotFound />} />
+          </Route>
         </Route>
         <Route path="/tags">
           <Route path="" element={<Tags />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -97,7 +97,13 @@ export default function Header() {
             </div>
           </div>
           <div className={menuOn ? cx('menu') : cx('blind')}>
-            <div className={cx('menu-wrapper')}>
+            <div
+              className={cx('menu-wrapper')}
+              onClick={() => {
+                setMenuOn(false);
+              }}
+              role="presentation"
+            >
               <Link to="/myvelog">
                 <div>내 벨로그</div>
               </Link>

--- a/src/components/HeaderFilter.module.scss
+++ b/src/components/HeaderFilter.module.scss
@@ -37,7 +37,6 @@
       .highlight {
         color: black;
         font-weight: bold;
-        border-bottom: 2px solid black;
       }
       .wider {
         width: 9rem;
@@ -118,6 +117,13 @@
       color: black;
       font-weight: bold;
     }
+  }
+  .underline {
+    width: 112px;
+    height: 2px;
+    position: absolute;
+    bottom: 0px;
+    background: var(--border1);
   }
 }
 @media (max-width: 1919px) {

--- a/src/components/HeaderFilter.tsx
+++ b/src/components/HeaderFilter.tsx
@@ -36,13 +36,13 @@ export default function HeaderFilter() {
 
   useEffect(() => {
     const initialDist = underlineDest - underlinePos;
-    setUnderlinePos(underlinePos + initialDist * 1.05);
+    setUnderlinePos(underlinePos + initialDist * 1.09);
     const timer1 = setTimeout(() => {
       setUnderlinePos(underlinePos + initialDist * 0.99);
-    }, 250);
+    }, 300);
     const timer2 = setTimeout(() => {
       setUnderlinePos(underlinePos + initialDist);
-    }, 500);
+    }, 600);
 
     return () => {
       clearTimeout(timer1);
@@ -181,7 +181,7 @@ export default function HeaderFilter() {
         style={{
           width: path === '/' || path === '/recent' ? '112px' : '144px',
           transform: `translate(${underlinePos}px)`,
-          transition: `transform 0.25s ease-out 0s`,
+          transition: `transform 0.3s ease-out 0s`,
         }}
       />
     </div>

--- a/src/components/HeaderFilter.tsx
+++ b/src/components/HeaderFilter.tsx
@@ -10,6 +10,8 @@ export default function HeaderFilter() {
 
   const [filterOn, setFilterOn] = useState(false);
   const [filterValue, setFilterValue] = useState('오늘');
+  const [underlinePos, setUnderlinePos] = useState(0);
+  const [underlineDest, setUnderlineDest] = useState(0);
 
   function openFilter() {
     if (filterOn === false) {
@@ -23,6 +25,30 @@ export default function HeaderFilter() {
     setFilterValue(e.target.innerHTML);
     setFilterOn(false);
   }
+
+  useEffect(() => {
+    if (path === '/') setUnderlineDest(0);
+    else if (path === '/recent') setUnderlineDest(112);
+    else if (path === '/lists/liked') setUnderlineDest(0);
+    else if (path === '/lists/read') setUnderlineDest(144);
+    else if (path === '/lists/following') setUnderlineDest(288);
+  }, [path]);
+
+  useEffect(() => {
+    const initialDist = underlineDest - underlinePos;
+    setUnderlinePos(underlinePos + initialDist * 1.05);
+    const timer1 = setTimeout(() => {
+      setUnderlinePos(underlinePos + initialDist * 0.99);
+    }, 250);
+    const timer2 = setTimeout(() => {
+      setUnderlinePos(underlinePos + initialDist);
+    }, 500);
+
+    return () => {
+      clearTimeout(timer1);
+      clearTimeout(timer2);
+    };
+  }, [underlineDest]);
 
   return (
     <div
@@ -150,6 +176,14 @@ export default function HeaderFilter() {
           # 태그 목록
         </Link>
       </div>
+      <div
+        className={cx('underline')}
+        style={{
+          width: path === '/' || path === '/recent' ? '112px' : '144px',
+          transform: `translate(${underlinePos}px)`,
+          transition: `transform 0.25s ease-out 0s`,
+        }}
+      />
     </div>
   );
 }

--- a/src/components/HomeContents.module.scss
+++ b/src/components/HomeContents.module.scss
@@ -1,12 +1,11 @@
 .contents {
   display: block;
   width: 1728px;
-  margin-top: 2rem;
+  min-height: 100vh;
   margin-left: auto;
   margin-right: auto;
   .container {
     display: flex;
-    margin-top: 2rem;
     main {
       flex: 1 1 0%;
       box-sizing: inherit;

--- a/src/components/HomeContents.tsx
+++ b/src/components/HomeContents.tsx
@@ -13,7 +13,6 @@ type HomeContentsProps = { posts: post[] };
 export default function HomeContents({ posts }: HomeContentsProps) {
   return (
     <div className={cx('contents')}>
-      <HeaderFilter />
       <div className={cx('container')}>
         <main>
           <div className={cx('posts')}>

--- a/src/contexts/LoginProvider.tsx
+++ b/src/contexts/LoginProvider.tsx
@@ -34,6 +34,12 @@ const initialSetting: loginSetting = {
 const loginValueContext = createContext<loginValue>(initialValue);
 const loginSettingContext = createContext<loginSetting>(initialSetting);
 
+axios.defaults.xsrfCookieName = 'csrftoken';
+axios.defaults.xsrfHeaderName = 'X-CSRFToken';
+axios.defaults.baseURL =
+  process.env.NODE_ENV === 'development' ? '' : 'https://api.7elog.store';
+axios.defaults.withCredentials = true;
+
 export default function LoginProvider({
   children,
 }: {
@@ -46,11 +52,6 @@ export default function LoginProvider({
   });
 
   const navigate = useNavigate();
-  axios.defaults.xsrfCookieName = 'csrftoken';
-  axios.defaults.xsrfHeaderName = 'X-CSRFToken';
-  axios.defaults.baseURL =
-    process.env.NODE_ENV === 'development' ? '' : 'https://api.7elog.store';
-  axios.defaults.withCredentials = true;
 
   const setting = useMemo(
     () => ({

--- a/src/pages/HeaderLayout.tsx
+++ b/src/pages/HeaderLayout.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import Header from '../components/Header';
+import HeaderFilter from '../components/HeaderFilter';
+import HeaderMoving from '../components/HeaderMoving';
+
+export default function HeaderLayout() {
+  return (
+    <div
+      style={{
+        backgroundColor: '#F8F9FA',
+      }}
+    >
+      <Header />
+      <div style={{ marginTop: '2rem' }} />
+      <HeaderFilter />
+      <HeaderMoving />
+      <Outlet />
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -22,17 +22,7 @@ function Home() {
     getVelog();
   }, []);
 
-  return (
-    <div
-      style={{
-        backgroundColor: '#F8F9FA',
-      }}
-    >
-      <Header />
-      <HeaderMoving />
-      <HomeContents posts={posts} />
-    </div>
-  );
+  return <HomeContents posts={posts} />;
 }
 
 export default Home;

--- a/src/pages/ListsFollowing.tsx
+++ b/src/pages/ListsFollowing.tsx
@@ -177,17 +177,7 @@ function ListsFollowing() {
   ];
   const [posts, setPosts] = useState(tempPosts);
 
-  return (
-    <div
-      style={{
-        backgroundColor: '#F8F9FA',
-      }}
-    >
-      <Header />
-      <HeaderMoving />
-      <HomeContents posts={posts} />
-    </div>
-  );
+  return <HomeContents posts={posts} />;
 }
 
 export default ListsFollowing;

--- a/src/pages/ListsLiked.tsx
+++ b/src/pages/ListsLiked.tsx
@@ -177,17 +177,7 @@ function ListsLiked() {
   ];
   const [posts, setPosts] = useState(tempPosts);
 
-  return (
-    <div
-      style={{
-        backgroundColor: '#F8F9FA',
-      }}
-    >
-      <Header />
-      <HeaderMoving />
-      <HomeContents posts={posts} />
-    </div>
-  );
+  return <HomeContents posts={posts} />;
 }
 
 export default ListsLiked;

--- a/src/pages/ListsRead.tsx
+++ b/src/pages/ListsRead.tsx
@@ -177,17 +177,7 @@ function ListsRead() {
   ];
   const [posts, setPosts] = useState(tempPosts);
 
-  return (
-    <div
-      style={{
-        backgroundColor: '#F8F9FA',
-      }}
-    >
-      <Header />
-      <HeaderMoving />
-      <HomeContents posts={posts} />
-    </div>
-  );
+  return <HomeContents posts={posts} />;
 }
 
 export default ListsRead;

--- a/src/pages/Personal.tsx
+++ b/src/pages/Personal.tsx
@@ -121,87 +121,67 @@ function Personal() {
   const tagQuery = new URLSearchParams(window.location.search).get('tag');
 
   return (
-    <div className={cx('page')}>
-      <Header />
-      <div className={cx('pageContent')}>
-        <UserIntro userInfo={currentUser} />
+    <div>
+      <div>
+        <section className={cx('searchSection')}>
+          <div className={cx('box')}>
+            <svg width="17" height="17" viewBox="0 0 17 17">
+              <path
+                fillRule="evenodd"
+                d="M13.66 7.36a6.3 6.3 0 1 1-12.598 0 6.3 6.3 0 0 1 12.598 0zm-1.73 5.772a7.36 7.36 0 1 1 1.201-1.201l3.636 3.635c.31.31.31.815 0 1.126l-.075.075a.796.796 0 0 1-1.126 0l-3.636-3.635z"
+                clipRule="evenodd"
+                fill="currentColor"
+              />
+            </svg>
+            <input
+              placeholder="검색어를 입력하세요"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+            />
+          </div>
+        </section>
+      </div>
+      <div className={cx('tagDiv')}>
         <div>
-          <div className={cx('pageIndex')}>
-            <Link to={`/@${currentUser.id}`} className={cx('index', 'active')}>
-              글
-            </Link>
-            <Link to={`/@${currentUser.id}/series`} className={cx('index')}>
-              시리즈
-            </Link>
-            <Link to={`/@${currentUser.id}/about`} className={cx('index')}>
-              소개
-            </Link>
-            <div className={cx('activeLine')} />
+          <div className={cx('tagList')}>
+            <div>
+              <div className={cx('title')}>태그 목록</div>
+              <ul>
+                <li
+                  className={cx(
+                    'tagElem',
+                    tagQuery === null ? 'tagActive' : 'none'
+                  )}
+                >
+                  <Link to={`/@${currentUser.id}`}>전체보기</Link>
+                  <span>({getPostnum('')})</span>
+                </li>
+                {detailedUser.tags.map((tag: string) => (
+                  <li
+                    className={cx(
+                      'tagElem',
+                      tagQuery === tag ? 'tagActive' : 'none'
+                    )}
+                  >
+                    <Link to={`/@${currentUser.id}?tag=${tag}`}>{tag}</Link>
+                    <span>({getPostnum(tag)})</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
         </div>
-        <div>
-          <div>
-            <section className={cx('searchSection')}>
-              <div className={cx('box')}>
-                <svg width="17" height="17" viewBox="0 0 17 17">
-                  <path
-                    fillRule="evenodd"
-                    d="M13.66 7.36a6.3 6.3 0 1 1-12.598 0 6.3 6.3 0 0 1 12.598 0zm-1.73 5.772a7.36 7.36 0 1 1 1.201-1.201l3.636 3.635c.31.31.31.815 0 1.126l-.075.075a.796.796 0 0 1-1.126 0l-3.636-3.635z"
-                    clipRule="evenodd"
-                    fill="currentColor"
-                  />
-                </svg>
-                <input
-                  placeholder="검색어를 입력하세요"
-                  value={query}
-                  onChange={e => setQuery(e.target.value)}
-                />
-              </div>
-            </section>
-          </div>
-          <div className={cx('tagDiv')}>
-            <div>
-              <div className={cx('tagList')}>
-                <div>
-                  <div className={cx('title')}>태그 목록</div>
-                  <ul>
-                    <li
-                      className={cx(
-                        'tagElem',
-                        tagQuery === null ? 'tagActive' : 'none'
-                      )}
-                    >
-                      <Link to={`/@${currentUser.id}`}>전체보기</Link>
-                      <span>({getPostnum('')})</span>
-                    </li>
-                    {detailedUser.tags.map((tag: string) => (
-                      <li
-                        className={cx(
-                          'tagElem',
-                          tagQuery === tag ? 'tagActive' : 'none'
-                        )}
-                      >
-                        <Link to={`/@${currentUser.id}?tag=${tag}`}>{tag}</Link>
-                        <span>({getPostnum(tag)})</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
+      </div>
 
-          <div>
-            <div className="postList">
-              {detailedUser.posts.map((postComp: post) => (
-                <BigPostComp
-                  key={postComp.id}
-                  postInfo={postComp}
-                  username={currentUser.id}
-                />
-              ))}
-            </div>
-          </div>
+      <div>
+        <div className="postList">
+          {detailedUser.posts.map((postComp: post) => (
+            <BigPostComp
+              key={postComp.id}
+              postInfo={postComp}
+              username={currentUser.id}
+            />
+          ))}
         </div>
       </div>
     </div>

--- a/src/pages/PersonalAbout.tsx
+++ b/src/pages/PersonalAbout.tsx
@@ -128,85 +128,62 @@ function PersonalAbout() {
   }
 
   return (
-    <div className={cx('page')}>
-      <Header />
-      <div className={cx('pageContent')}>
-        <UserIntro userInfo={currentUser} />
-        <div>
-          <div className={cx('pageIndex')}>
-            <Link to={`/@${currentUser.id}`} className={cx('index')}>
-              글
-            </Link>
-            <Link to={`/@${currentUser.id}/series`} className={cx('index')}>
-              시리즈
-            </Link>
-            <Link
-              to={`/@${currentUser.id}/about`}
-              className={cx('index', 'active')}
+    <div>
+      {!isWriting && detailedUser.about === '' && (
+        <div className={cx('empty')}>
+          <img
+            src="https://static.velog.io/static/media/undraw_empty.5fd6f2b8.svg"
+            alt="empty about"
+          />
+          <div className={cx('message')}>소개가 작성되지 않았습니다.</div>
+          {loginUser && (
+            <button
+              type="button"
+              color="teal"
+              className={cx('addIntro')}
+              onClick={writeOpen}
             >
-              소개
-            </Link>
-            <div className={cx('activeLine')} />
-          </div>
+              소개 글 작성하기
+            </button>
+          )}
         </div>
+      )}
+      {!isWriting && detailedUser.about !== '' && (
         <div>
-          {!isWriting && detailedUser.about === '' && (
-            <div className={cx('empty')}>
-              <img
-                src="https://static.velog.io/static/media/undraw_empty.5fd6f2b8.svg"
-                alt="empty about"
-              />
-              <div className={cx('message')}>소개가 작성되지 않았습니다.</div>
-              {loginUser && (
-                <button
-                  type="button"
-                  color="teal"
-                  className={cx('addIntro')}
-                  onClick={writeOpen}
-                >
-                  소개 글 작성하기
-                </button>
-              )}
+          {loginUser && (
+            <div className={cx('buttonDiv')}>
+              <button
+                type="button"
+                color="teal"
+                className={cx('button')}
+                onClick={writeOpen}
+              >
+                수정하기
+              </button>
             </div>
           )}
-          {!isWriting && detailedUser.about !== '' && (
-            <div>
-              {loginUser && (
-                <div className={cx('buttonDiv')}>
-                  <button
-                    type="button"
-                    color="teal"
-                    className={cx('button')}
-                    onClick={writeOpen}
-                  >
-                    수정하기
-                  </button>
-                </div>
-              )}
-              <div className={cx('intro')}>{newAbout}</div>
-            </div>
-          )}
-          {isWriting && (
-            <div>
-              <div className={cx('buttonDiv')}>
-                <button
-                  type="button"
-                  color="teal"
-                  className={cx('button')}
-                  onClick={writeClose}
-                >
-                  저장하기
-                </button>
-              </div>
-              <textarea
-                defaultValue={detailedUser.about}
-                placeholder="소개 문구를 입력하세요."
-                onChange={e => setAbout(e.target.value)}
-              />
-            </div>
-          )}
+          <div className={cx('intro')}>{newAbout}</div>
         </div>
-      </div>
+      )}
+      {isWriting && (
+        <div>
+          <div className={cx('buttonDiv')}>
+            <button
+              type="button"
+              color="teal"
+              className={cx('button')}
+              onClick={writeClose}
+            >
+              저장하기
+            </button>
+          </div>
+          <textarea
+            defaultValue={detailedUser.about}
+            placeholder="소개 문구를 입력하세요."
+            onChange={e => setAbout(e.target.value)}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/PersonalLayout.module.scss
+++ b/src/pages/PersonalLayout.module.scss
@@ -1,0 +1,63 @@
+.page {
+  margin: 0;
+  padding: 0 0 4rem;
+  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue',
+    'Apple SD Gothic Neo', 'Malgun Gothic', '맑은 고딕', 나눔고딕,
+    'Nanum Gothic', 'Noto Sans KR', 'Noto Sans CJK KR', arial, 돋움, Dotum,
+    Tahoma, Geneva, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  color: var(--bg-element5);
+  box-sizing: border-box;
+}
+
+.pageContent {
+  width: 82%;
+  max-width: 768px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.pageIndex {
+  margin-top: 4.5rem;
+  margin-bottom: 4.5rem;
+  display: flex;
+  -webkit-box-pack: center;
+  justify-content: center;
+  position: relative;
+  .index {
+    display: flex;
+    -webkit-box-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    justify-content: center;
+    font-size: 1.325rem;
+    width: 8rem;
+    height: 3rem;
+    color: var(--text2);
+    text-decoration: none;
+    transition: color 0.25s ease-in-out 0s;
+    font-weight: 600;
+  }
+  .active {
+    color: var(--primary2);
+  }
+}
+
+.activeLine {
+  width: 8rem;
+  height: 2px;
+  left: 58%;
+  background: var(--primary2);
+  bottom: -2px;
+  position: absolute;
+  transition: left 0.25s ease-in-out 0s;
+}
+
+.underline {
+  width: 8rem;
+  height: 2px;
+  position: absolute;
+  margin-right: 16rem;
+  bottom: -2px;
+  background: var(--primary2);
+}

--- a/src/pages/PersonalLayout.tsx
+++ b/src/pages/PersonalLayout.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { Link, Outlet, useLocation } from 'react-router-dom';
+// eslint-disable-next-line import/extensions,import/no-unresolved
+import classNames from 'classnames/bind';
+// eslint-disable-next-line import/extensions,import/no-unresolved
+import Header from '../components/Header';
+import HeaderMoving from '../components/HeaderMoving';
+// eslint-disable-next-line import/extensions,import/no-unresolved
+import UserIntro from '../components/UserIntro';
+// eslint-disable-next-line import/extensions,import/no-unresolved
+import styles from './PersonalLayout.module.scss';
+// eslint-disable-next-line import/extensions,import/no-unresolved,camelcase
+import { user } from '../contexts/types';
+
+const cx = classNames.bind(styles);
+const currentUser: user = {
+  id: 'myId',
+  velog_name: 'my_velog',
+  email: 'mail',
+  username: '이름',
+  userImg: '',
+  description: '내 벨로그',
+  github: 'github',
+  twitter: 'twitter',
+  facebook: 'facebook',
+  homepage: 'https://localhost:3000',
+  mail: 'myId@snu.ac.kr',
+};
+
+function PersonalLayout() {
+  const path = useLocation().pathname;
+  const [underlinePos, setUnderlinePos] = useState(0);
+  const [underlineDest, setUnderlineDest] = useState(0);
+
+  useEffect(() => {
+    if (path === `/@${currentUser.id}`) setUnderlineDest(0);
+    else if (path === `/@${currentUser.id}/series`) setUnderlineDest(128);
+    else if (path === `/@${currentUser.id}/about`) setUnderlineDest(256);
+  }, [path]);
+
+  useEffect(() => {
+    const initialDist = underlineDest - underlinePos;
+    setUnderlinePos(underlinePos + initialDist);
+  }, [underlineDest]);
+
+  return (
+    <div className={cx('page')}>
+      <Header />
+      <HeaderMoving />
+      <div className={cx('pageContent')}>
+        <UserIntro userInfo={currentUser} />
+        <div>
+          <div className={cx('pageIndex')}>
+            <Link
+              to={`/@${currentUser.id}`}
+              className={cx('index', {
+                active: path === `/@${currentUser.id}`,
+              })}
+            >
+              글
+            </Link>
+            <Link
+              to={`/@${currentUser.id}/series`}
+              className={cx('index', {
+                active: path === `/@${currentUser.id}/series`,
+              })}
+            >
+              시리즈
+            </Link>
+            <Link
+              to={`/@${currentUser.id}/about`}
+              className={cx('index', {
+                active: path === `/@${currentUser.id}/about`,
+              })}
+            >
+              소개
+            </Link>
+            <div
+              className={cx('underline')}
+              style={{
+                transform: `translate(${underlinePos}px)`,
+                transition: `transform 0.25s ease-out 0s`,
+              }}
+            />
+          </div>
+        </div>
+        <Outlet />
+      </div>
+    </div>
+  );
+}
+
+export default PersonalLayout;

--- a/src/pages/PersonalSeries.tsx
+++ b/src/pages/PersonalSeries.tsx
@@ -134,58 +134,35 @@ function PersonalSeries() {
   }
 
   return (
-    <div className={cx('page')}>
-      <Header />
-      <div className={cx('pageContent')}>
-        <UserIntro userInfo={currentUser} />
-        <div>
-          <div className={cx('pageIndex')}>
-            <Link to={`/@${currentUser.id}`} className={cx('index')}>
-              글
-            </Link>
+    <div>
+      <div className={cx('seriesList')}>
+        {detailedUser.series.map((seriesInfo: series) => (
+          <div className={cx('seriesDiv')}>
             <Link
-              to={`/@${currentUser.id}/series`}
-              className={cx('index', 'active')}
+              to={`/@${seriesInfo.authorId}/series/${seriesInfo.url}`}
+              className={cx('link')}
             >
-              시리즈
-            </Link>
-            <Link to={`/@${currentUser.id}/about`} className={cx('index')}>
-              소개
-            </Link>
-            <div className={cx('activeLine')} />
-          </div>
-        </div>
-        <div>
-          <div className={cx('seriesList')}>
-            {detailedUser.series.map((seriesInfo: series) => (
-              <div className={cx('seriesDiv')}>
-                <Link
-                  to={`/@${seriesInfo.authorId}/series/${seriesInfo.url}`}
-                  className={cx('link')}
-                >
-                  <div>
-                    <img src={seriesInfo.photo} alt="thumbnail" />
-                  </div>
-                </Link>
-                <h4>
-                  <Link
-                    to={`/@${seriesInfo.authorId}/series/${seriesInfo.url}`}
-                    className={cx('link')}
-                  >
-                    {seriesInfo.title}
-                  </Link>
-                </h4>
-                <div className={cx('subInfo')}>
-                  <span className={cx('count')}>
-                    {seriesInfo.postNum}개의 포스트
-                  </span>
-                  <span className={cx('dot')}>·</span>
-                  마지막 업테이트 {timeSetting(seriesInfo.update)}
-                </div>
+              <div>
+                <img src={seriesInfo.photo} alt="thumbnail" />
               </div>
-            ))}
+            </Link>
+            <h4>
+              <Link
+                to={`/@${seriesInfo.authorId}/series/${seriesInfo.url}`}
+                className={cx('link')}
+              >
+                {seriesInfo.title}
+              </Link>
+            </h4>
+            <div className={cx('subInfo')}>
+              <span className={cx('count')}>
+                {seriesInfo.postNum}개의 포스트
+              </span>
+              <span className={cx('dot')}>·</span>
+              마지막 업테이트 {timeSetting(seriesInfo.update)}
+            </div>
           </div>
-        </div>
+        ))}
       </div>
     </div>
   );

--- a/src/pages/Recent.tsx
+++ b/src/pages/Recent.tsx
@@ -22,17 +22,7 @@ function Recent() {
     getVelogRecent();
   }, []);
 
-  return (
-    <div
-      style={{
-        backgroundColor: '#F8F9FA',
-      }}
-    >
-      <Header />
-      <HeaderMoving />
-      <HomeContents posts={posts} />
-    </div>
-  );
+  return <HomeContents posts={posts} />;
 }
 
 export default Recent;


### PR DESCRIPTION
react-router-dom 의 Outlet을 활용하면 velog처럼 탭 이동할 때 탭 아래의 underline이 이동하는 css 애니메이션을 구현할 수 있을 것 같아서 변경해봤습니다.

`Home ↔ Recent`  `ListLiked ↔ ListRead ↔ ListFollowing`
`Personal ↔ PersonalSeries ↔ PersonalAbout`
위 페이지 간의 공통 컴포넌트를 HeaderLayout과 PersonalLayout에 이동시키고 실제 페이지 내용물은 Outlet으로 들어가게 router 구조를 변경하였습니다.