### PR TITLE
do not show empty tag in tag page

### DIFF
--- a/src/pages/Tags.tsx
+++ b/src/pages/Tags.tsx
@@ -76,18 +76,25 @@ function Tags() {
           </div>
         </div>
         <section className={cx('tagSection')}>
-          {tagList.map((tagInfo: tagGetType) => (
-            <div className={cx('tagComp')}>
-              <div>
-                <Link to={`/tags/${tagInfo.tag_name}`} className={cx('title')}>
-                  {tagInfo.tag_name}
-                </Link>
-              </div>
-              <div className={cx('count')}>
-                총 {tagInfo.postCount}개의 포스트
-              </div>
-            </div>
-          ))}
+          {tagList.map(
+            (tagInfo: tagGetType) =>
+              tagInfo.tag_name !== '' &&
+              tagInfo.postCount !== 0 && (
+                <div className={cx('tagComp')}>
+                  <div>
+                    <Link
+                      to={`/tags/${tagInfo.tag_name}`}
+                      className={cx('title')}
+                    >
+                      {tagInfo.tag_name}
+                    </Link>
+                  </div>
+                  <div className={cx('count')}>
+                    총 {tagInfo.postCount}개의 포스트
+                  </div>
+                </div>
+              )
+          )}
         </section>
       </main>
     </div>


### PR DESCRIPTION
이름이 없는 태그는 클릭해도 이동이 안되어서 이름이 없거나 포스트 수가 0인 포스트는 숨김처리 했습니다